### PR TITLE
Fix: Correct favorite image background in desktop application

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/plcoding/bookpedia/utils/utils.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/plcoding/bookpedia/utils/utils.android.kt
@@ -1,0 +1,3 @@
+package com.plcoding.bookpedia.utils
+
+actual fun getPlatformType(): PlatformType = PlatformType.ANDROID

--- a/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/book/presentation/book_detail/components/BlurredImageBackground.kt
+++ b/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/book/presentation/book_detail/components/BlurredImageBackground.kt
@@ -50,6 +50,8 @@ import com.plcoding.bookpedia.core.presentation.DarkBlue
 import com.plcoding.bookpedia.core.presentation.DesertWhite
 import com.plcoding.bookpedia.core.presentation.PulseAnimation
 import com.plcoding.bookpedia.core.presentation.SandYellow
+import com.plcoding.bookpedia.utils.PlatformType
+import com.plcoding.bookpedia.utils.getPlatformType
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -151,6 +153,10 @@ fun BlurredImageBackground(
                             )
                         }
                         else -> {
+                            val gradientRadius = when(getPlatformType()) {
+                                PlatformType.DESKTOP -> 28f
+                                else -> 70f
+                            }
                             Box {
                                 Image(
                                     painter = if(result.isSuccess) painter else {
@@ -175,7 +181,7 @@ fun BlurredImageBackground(
                                                 colors = listOf(
                                                     SandYellow, Color.Transparent
                                                 ),
-                                                radius = 70f
+                                                radius = gradientRadius
                                             )
                                         )
                                 ) {

--- a/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/book/presentation/book_detail/components/BlurredImageBackground.kt
+++ b/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/book/presentation/book_detail/components/BlurredImageBackground.kt
@@ -129,6 +129,10 @@ fun BlurredImageBackground(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth()
         ) {
+            val gradientRadius = when(getPlatformType()) {
+                PlatformType.DESKTOP -> 28f
+                else -> 70f
+            }
             Spacer(modifier = Modifier.fillMaxHeight(0.15f))
             ElevatedCard(
                 modifier = Modifier
@@ -153,10 +157,6 @@ fun BlurredImageBackground(
                             )
                         }
                         else -> {
-                            val gradientRadius = when(getPlatformType()) {
-                                PlatformType.DESKTOP -> 28f
-                                else -> 70f
-                            }
                             Box {
                                 Image(
                                     painter = if(result.isSuccess) painter else {

--- a/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/utils/utils.kt
+++ b/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/utils/utils.kt
@@ -1,0 +1,9 @@
+package com.plcoding.bookpedia.utils
+
+expect fun getPlatformType(): PlatformType
+
+enum class PlatformType {
+    ANDROID,
+    IOS,
+    DESKTOP
+}

--- a/composeApp/src/desktopMain/kotlin/com/plcoding/bookpedia/utils/utils.kt
+++ b/composeApp/src/desktopMain/kotlin/com/plcoding/bookpedia/utils/utils.kt
@@ -1,0 +1,3 @@
+package com.plcoding.bookpedia.utils
+
+actual fun getPlatformType(): PlatformType  = PlatformType.DESKTOP

--- a/composeApp/src/iosMain/kotlin/com/plcoding/bookpedia/utils/utils.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/plcoding/bookpedia/utils/utils.ios.kt
@@ -1,0 +1,3 @@
+package com.plcoding.bookpedia.utils
+
+actual fun getPlatformType(): PlatformType = PlatformType.IOS


### PR DESCRIPTION
Ensured the gradient behaves consistently across different platforms by making the radius dynamic based on the platform type.

**Issue**

![image](https://github.com/user-attachments/assets/f248034a-83f3-4014-a152-236fbb9d8df2)


**Result**

![image](https://github.com/user-attachments/assets/2774c339-e7b3-441a-a0ed-151df0c7ad9c)
