### PR TITLE
Optimizing BookListViewModel using single StateFlow with combine

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/book/data/database/BookDatabaseConstructor.kt
+++ b/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/book/data/database/BookDatabaseConstructor.kt
@@ -1,8 +1,7 @@
 package com.plcoding.bookpedia.book.data.database
 
 import androidx.room.RoomDatabaseConstructor
-
-@Suppress("NO_ACTUAL_FOR_EXPECT")
+@Suppress("KotlinNoActualForExpect")
 expect object BookDatabaseConstructor: RoomDatabaseConstructor<FavoriteBookDatabase> {
     override fun initialize(): FavoriteBookDatabase
 }

--- a/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/book/presentation/book_list/BookListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/book/presentation/book_list/BookListViewModel.kt
@@ -4,132 +4,94 @@ package com.plcoding.bookpedia.book.presentation.book_list
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.plcoding.bookpedia.book.domain.Book
 import com.plcoding.bookpedia.book.domain.BookRepository
+import com.plcoding.bookpedia.core.domain.Result
 import com.plcoding.bookpedia.core.domain.onError
 import com.plcoding.bookpedia.core.domain.onSuccess
+import com.plcoding.bookpedia.core.presentation.UiText
 import com.plcoding.bookpedia.core.presentation.toUiText
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 
 class BookListViewModel(
     private val bookRepository: BookRepository
 ) : ViewModel() {
 
-    private var cachedBooks = emptyList<Book>()
-    private var searchJob: Job? = null
-    private var observeFavoriteJob: Job? = null
+    private val _searchQuery = MutableStateFlow("Kotlin")
+    private val _selectedTabIndex = MutableStateFlow(0)
 
-    private val _state = MutableStateFlow(BookListState())
-    val state = _state
-        .onStart {
-            if(cachedBooks.isEmpty()) {
-                observeSearchQuery()
+    private val favoriteBooks = bookRepository.getFavoriteBooks()
+
+    private var cachedBooks: List<Book> = emptyList()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val searchResults = _searchQuery
+        .debounce(400L)
+        .distinctUntilChanged()
+        .flatMapLatest { query ->
+            when {
+                query.isBlank() -> flow{ emit(Result.Success(cachedBooks))}
+                query.length < 2 -> flow { emit(Result.Success(cachedBooks)) }
+                else -> flow {
+                    bookRepository.searchBooks(query)
+                        .onSuccess { searchResults ->
+                            emit(Result.Success(searchResults))
+                        }
+                        .onError { error ->
+                            emit(Result.Error(error))
+                        }
+
+                }
             }
-            observeFavoriteBooks()
         }
-        .stateIn(
-            viewModelScope,
-            SharingStarted.WhileSubscribed(5000L),
-            _state.value
+
+    val state = combine(
+        _searchQuery,
+        _selectedTabIndex,
+        favoriteBooks,
+        searchResults
+    ) { query, tab, favorites, searchResult ->
+        var errorMessage: UiText? = null
+        var searchList: List<Book> = emptyList()
+        var isLoading = false
+
+        when(searchResult){
+            is Result.Error -> {
+                errorMessage = searchResult.error.toUiText()
+            }
+            is Result.Success -> {
+                searchList = searchResult.data
+            }
+        }
+
+        BookListState(
+            searchQuery = query,
+            selectedTabIndex = tab,
+            favoriteBooks = favorites,
+            searchResults = searchList,
+            errorMessage = errorMessage,
+            isLoading = isLoading
         )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000L),
+        BookListState()
+    )
 
     fun onAction(action: BookListAction) {
         when (action) {
-            is BookListAction.OnBookClick -> {
-
-            }
-
-            is BookListAction.OnSearchQueryChange -> {
-                _state.update {
-                    it.copy(searchQuery = action.query)
-                }
-            }
-
-            is BookListAction.OnTabSelected -> {
-                _state.update {
-                    it.copy(selectedTabIndex = action.index)
-                }
-            }
+            is BookListAction.OnSearchQueryChange -> _searchQuery.value = action.query
+            is BookListAction.OnTabSelected -> _selectedTabIndex.value = action.index
+            is BookListAction.OnBookClick -> { }
         }
     }
-
-    private fun observeFavoriteBooks() {
-        observeFavoriteJob?.cancel()
-        observeFavoriteJob = bookRepository
-            .getFavoriteBooks()
-            .onEach { favoriteBooks ->
-                _state.update { it.copy(
-                    favoriteBooks = favoriteBooks
-                ) }
-            }
-            .launchIn(viewModelScope)
-    }
-
-    private fun observeSearchQuery() {
-        state
-            .map { it.searchQuery }
-            .distinctUntilChanged()
-            .debounce(500L)
-            .onEach { query ->
-                when {
-                    query.isBlank() -> {
-                        _state.update {
-                            it.copy(
-                                errorMessage = null,
-                                searchResults = cachedBooks
-                            )
-                        }
-                    }
-
-                    query.length >= 2 -> {
-                        searchJob?.cancel()
-                        searchJob = searchBooks(query)
-                    }
-                }
-            }
-            .launchIn(viewModelScope)
-    }
-
-    private fun searchBooks(query: String) = viewModelScope.launch {
-        _state.update {
-            it.copy(
-                isLoading = true
-            )
-        }
-        bookRepository
-            .searchBooks(query)
-            .onSuccess { searchResults ->
-                _state.update {
-                    it.copy(
-                        isLoading = false,
-                        errorMessage = null,
-                        searchResults = searchResults
-                    )
-                }
-            }
-            .onError { error ->
-                _state.update {
-                    it.copy(
-                        searchResults = emptyList(),
-                        isLoading = false,
-                        errorMessage = error.toUiText()
-                    )
-                }
-            }
-    }
-
 }

--- a/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/book/presentation/book_list/BookListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/plcoding/bookpedia/book/presentation/book_list/BookListViewModel.kt
@@ -44,6 +44,7 @@ class BookListViewModel(
                 else -> flow {
                     bookRepository.searchBooks(query)
                         .onSuccess { searchResults ->
+                            cachedBooks = searchResults
                             emit(Result.Success(searchResults))
                         }
                         .onError { error ->


### PR DESCRIPTION
### On the BookListScreen 
we have  the states 

- **searchQuery,**
-  **selectedTabIndex** 
- **searchBooks** 
-  **favoriteBooks**

## Search Query and SelectedTabIndex
**SearchQuery** and **SelectedTabIndex** were converted to MutableStateFlow

## FavoriteBooks
 We've already had **Flow** -> **bookRepository.getFavoriteBooks()**, which returns from database 
So, We don't need to change

## SearchBooks
**searchBooks** are changing whenever **searchQuery** are changed
But , **bookRepository.searchBooks(query)** don't return **Flow**
So, We made this -> 
We made **searchResults** that will return as  Flow<Result>
We **don't need to cancel Job manually** cause we used **flatMapLatest**
```
    private val searchResults = _searchQuery
        .debounce(400L)
        .distinctUntilChanged()
        .flatMapLatest { query ->
            when {
                query.isBlank() -> flow{ emit(Result.Success(cachedBooks))}
                query.length < 2 -> flow { emit(Result.Success(cachedBooks)) }
                else -> flow {
                    bookRepository.searchBooks(query)
                        .onSuccess { searchResults ->
                            emit(Result.Success(searchResults))
                        }
                        .onError { error ->
                            emit(Result.Error(error))
                        }

                }
            }
        }
```
### Combine flows as one single StateFlow
Finally , I combined above flows with **combine** operator to get single StateFlow 
These changes make the code more reactive, concise, and easier to maintain, while ensuring UI state updates correctly for searches and tab selection.
